### PR TITLE
feat: Add close button to playlist

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -463,6 +463,17 @@
             flex: 1;
         }
 
+        .playlist h3 {
+            position: relative;
+        }
+
+        #closePlaylistBtn {
+            position: absolute;
+            top: -10px;
+            right: -10px;
+            padding: 5px 10px;
+        }
+
         .bpm-display {
             text-align: center;
             font-size: 1.1rem;

--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
 
         <div class="playlist-container">
             <div class="playlist" id="playlist">
-                <h3>Playlist</h3>
+                <h3>Playlist <button class="control-btn" id="closePlaylistBtn" onclick="closePlaylist()">❌</button></h3>
                 <div id="playlistItems"></div>
                 <div class="playlist-controls">
                     <button class="control-btn" onclick="document.getElementById('addTracksInput').click()">➕ Add Tracks</button>

--- a/js/main.js
+++ b/js/main.js
@@ -1156,6 +1156,12 @@ class Deck {
             }
         }
 
+        function closePlaylist() {
+            const container = document.querySelector('.playlist-container');
+            container.classList.add('collapsed');
+            saveSettings();
+        }
+
         function togglePlaylist() {
             const container = document.querySelector('.playlist-container');
             container.classList.toggle('collapsed');


### PR DESCRIPTION
Adds a close button to the top right of the playlist view. This allows the user to hide the playlist directly from the playlist view itself. The existing playlist button in the main header still functions as a toggle.