### PR TITLE
Fix: Playlist is now closed by default on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
             </div>
         </main>
 
-        <div class="playlist-container">
+        <div class="playlist-container collapsed">
             <div class="playlist" id="playlist">
                 <h3>Playlist <button class="control-btn" id="closePlaylistBtn" onclick="closePlaylist()">❌</button></h3>
                 <div id="playlistItems"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -1125,7 +1125,9 @@ class Deck {
                 document.getElementById('tempoRange').value = settings.tempoRange;
             }
 
-            if (settings.playlistCollapsed) {
+            if (settings.playlistCollapsed === false) {
+                document.querySelector('.playlist-container').classList.remove('collapsed');
+            } else if (settings.playlistCollapsed) {
                 document.querySelector('.playlist-container').classList.add('collapsed');
             }
 


### PR DESCRIPTION
The playlist overlay was previously open by default when the page loaded for the first time. This change makes the playlist closed by default.

- Adds the `collapsed` class to the `playlist-container` in `index.html` to set the default state to closed.
- Updates the `loadSettings` function in `js/main.js` to correctly load the user's preference from localStorage, ensuring the playlist's state (open/closed) is preserved across sessions.